### PR TITLE
chore: clean up unused pnpm catalog entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"keywords": [],
 	"author": "",
 	"license": "ISC",
-	"packageManager": "pnpm@10.26.2",
+	"packageManager": "pnpm@10.27.0",
 	"devDependencies": {
 		"@biomejs/biome": "catalog:",
 		"@effect/language-service": "catalog:",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,15 +6,13 @@ catalog:
   '@base-ui/react': ^1.0.0
   '@biomejs/biome': ^2.3.10
   '@cloudflare/vite-plugin': ^1.19.0
+  '@effect-atom/atom': ^0.4.11
+  '@effect-atom/atom-react': ^0.4.4
   '@effect/cli': ^0.73.0
-  '@effect/cluster': latest
-  '@effect/experimental': 0.58.0
   '@effect/language-service': latest
   '@effect/platform': 0.94.0
   '@effect/platform-bun': ^0.87.0
   '@effect/rpc': ^0.73.0
-  '@effect-atom/atom': ^0.4.11
-  '@effect-atom/atom-react': ^0.4.4
   '@gqloom/core': ^0.14.2
   '@gqloom/effect': ^0.13.0
   '@opentui/core': 0.1.63
@@ -36,7 +34,6 @@ catalog:
   graphql-yoga: ^5.18.0
   hono: ^4.11.1
   normalize-url: ^8.1.0
-  open-graph-scraper: ^6.11.0
   react: 19.2.3
   react-relay: ^20.1.1
   react-router: ^7.11.0
@@ -44,9 +41,9 @@ catalog:
   relay-runtime: ^20.1.1
   turbo: ^2.7.0
   typescript: ^5.9.3
-  url-metadata: ^5.4.1
-  vite-plugin-relay: ^2.1.0
   wrangler: ^4.56.0
+
+cleanupUnusedCatalogs: true
 
 onlyBuiltDependencies:
   - '@parcel/watcher'


### PR DESCRIPTION
## Summary
- Remove unused catalog entries that weren't referenced via `catalog:` protocol
- Enable automatic catalog cleanup on future installs

## Changes
- **Removed unused entries**: `@effect/cluster`, `@effect/experimental`, `open-graph-scraper`, `url-metadata`, `vite-plugin-relay`
- **Added setting**: `cleanupUnusedCatalogs: true` in pnpm-workspace.yaml
- **Bumped pnpm**: 10.26.2 → 10.27.0

## Why
These catalog entries existed but weren't referenced in any package.json using the `catalog:` protocol. The new `cleanupUnusedCatalogs` setting (pnpm v10.15.0+) will automatically remove any future unused entries during `pnpm install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)